### PR TITLE
Add build and install directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+/build/
+/install/
 
 # CLion
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can


### PR DESCRIPTION
## Summary
- add `/build/` to `.gitignore`
- add `/install/` to `.gitignore`

## Testing
- not run (gitignore-only change)