### PR TITLE
Fix CMake SPDX headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,19 @@ AI agents) must follow these instructions.
 - All source files must carry an **SPDX license header** as the very first
   non-blank line(s).
 - The required identifier is `LGPL-2.1-or-later`.
-- C/C++ and CMake style:
+- C/C++ style:
   ```cpp
   // SPDX-License-Identifier: LGPL-2.1-or-later
   // Copyright (C) 2024 G4OCCT Contributors
   ```
-- YAML/CMake `#`-comment style:
+- CMake `#`-comment style:
+  ```cmake
+  # cmake-format: off
+  # SPDX-License-Identifier: LGPL-2.1-or-later
+  # Copyright (C) 2024 G4OCCT Contributors
+  # cmake-format: on
+  ```
+- YAML `#`-comment style:
   ```cmake
   # SPDX-License-Identifier: LGPL-2.1-or-later
   # Copyright (C) 2024 G4OCCT Contributors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -1,5 +1,7 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/src/examples/B1/CMakeLists.txt
+++ b/src/examples/B1/CMakeLists.txt
@@ -1,5 +1,7 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 add_subdirectory(B1)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/src/tests/downstream_test/CMakeLists.txt
+++ b/src/tests/downstream_test/CMakeLists.txt
@@ -1,5 +1,7 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later Copyright (C) 2024 G4OCCT
-# Contributors
+# cmake-format: off
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright (C) 2024 G4OCCT Contributors
+# cmake-format: on
 
 # Minimal CMake project used as a CTest integration test to verify that a
 # downstream project can consume G4OCCT via find_package after installation.


### PR DESCRIPTION
## Summary
- replace malformed SPDX headers in repository CMakeLists.txt files with the required cmake-format guarded block
- update AGENTS.md to document the exact CMake header template for future files

## Testing
- git --no-pager diff --check
