### PR TITLE
app: derive macro path at runtime to fix spack relocation

### DIFF
--- a/src/app/g4occt/CMakeLists.txt
+++ b/src/app/g4occt/CMakeLists.txt
@@ -25,12 +25,13 @@ target_link_libraries(g4occt PRIVATE G4OCCT::G4OCCT ${Geant4_LIBRARIES})
 # ${CMAKE_CURRENT_BINARY_DIR}/macros/ so the layout mirrors the install tree.
 
 set(G4OCCT_MACRO_DIR_BUILD "${CMAKE_CURRENT_BINARY_DIR}/macros")
-set(G4OCCT_MACRO_DIR_INSTALL "${CMAKE_INSTALL_FULL_DATADIR}/g4occt/macros")
 
-# Embed both directories directly as compile definitions — no generated header.
-target_compile_definitions(
-  g4occt PRIVATE G4OCCT_MACRO_DIR_INSTALL="${G4OCCT_MACRO_DIR_INSTALL}"
-                 G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}")
+# Embed the build-tree directory as a compile definition for the in-tree
+# developer / CTest fallback.  The installed path is no longer hardcoded;
+# main.cc derives it at runtime relative to the executable so the binary
+# survives spack relocation.
+target_compile_definitions(g4occt PRIVATE
+    G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}")
 
 # Copy macro files into the build-tree macros/ subdirectory.
 foreach(_mac init_vis gui init_batch run_output)

--- a/src/app/g4occt/CMakeLists.txt
+++ b/src/app/g4occt/CMakeLists.txt
@@ -30,8 +30,8 @@ set(G4OCCT_MACRO_DIR_BUILD "${CMAKE_CURRENT_BINARY_DIR}/macros")
 # developer / CTest fallback.  The installed path is no longer hardcoded;
 # main.cc derives it at runtime relative to the executable so the binary
 # survives spack relocation.
-target_compile_definitions(g4occt PRIVATE
-    G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}")
+target_compile_definitions(
+  g4occt PRIVATE G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}")
 
 # Copy macro files into the build-tree macros/ subdirectory.
 foreach(_mac init_vis gui init_batch run_output)

--- a/src/app/g4occt/CMakeLists.txt
+++ b/src/app/g4occt/CMakeLists.txt
@@ -27,11 +27,16 @@ target_link_libraries(g4occt PRIVATE G4OCCT::G4OCCT ${Geant4_LIBRARIES})
 set(G4OCCT_MACRO_DIR_BUILD "${CMAKE_CURRENT_BINARY_DIR}/macros")
 
 # Embed the build-tree directory as a compile definition for the in-tree
-# developer / CTest fallback.  The installed path is no longer hardcoded;
-# main.cc derives it at runtime relative to the executable so the binary
+# developer / CTest fallback.  Also embed CMAKE_INSTALL_DATADIR so that
+# main.cc can construct the runtime-relative install path correctly even when
+# a packager sets a non-standard datadir (e.g. share64).  The installed
+# prefix itself is derived at runtime relative to the executable so the binary
 # survives spack relocation.
 target_compile_definitions(
-  g4occt PRIVATE G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}")
+  g4occt
+  PRIVATE
+    G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}"
+    G4OCCT_INSTALL_DATADIR="${CMAKE_INSTALL_DATADIR}")
 
 # Copy macro files into the build-tree macros/ subdirectory.
 foreach(_mac init_vis gui init_batch run_output)

--- a/src/app/g4occt/CMakeLists.txt
+++ b/src/app/g4occt/CMakeLists.txt
@@ -27,16 +27,14 @@ target_link_libraries(g4occt PRIVATE G4OCCT::G4OCCT ${Geant4_LIBRARIES})
 set(G4OCCT_MACRO_DIR_BUILD "${CMAKE_CURRENT_BINARY_DIR}/macros")
 
 # Embed the build-tree directory as a compile definition for the in-tree
-# developer / CTest fallback.  Also embed CMAKE_INSTALL_DATADIR so that
-# main.cc can construct the runtime-relative install path correctly even when
-# a packager sets a non-standard datadir (e.g. share64).  The installed
-# prefix itself is derived at runtime relative to the executable so the binary
-# survives spack relocation.
+# developer / CTest fallback.  Also embed CMAKE_INSTALL_DATADIR so that main.cc
+# can construct the runtime-relative install path correctly even when a packager
+# sets a non-standard datadir (e.g. share64).  The installed prefix itself is
+# derived at runtime relative to the executable so the binary survives spack
+# relocation.
 target_compile_definitions(
-  g4occt
-  PRIVATE
-    G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}"
-    G4OCCT_INSTALL_DATADIR="${CMAKE_INSTALL_DATADIR}")
+  g4occt PRIVATE G4OCCT_MACRO_DIR_BUILD="${G4OCCT_MACRO_DIR_BUILD}"
+                 G4OCCT_INSTALL_DATADIR="${CMAKE_INSTALL_DATADIR}")
 
 # Copy macro files into the build-tree macros/ subdirectory.
 foreach(_mac init_vis gui init_batch run_output)

--- a/src/app/g4occt/main.cc
+++ b/src/app/g4occt/main.cc
@@ -25,10 +25,70 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
+#include <filesystem>
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+#  include <mach-o/dyld.h>
+#endif
+
 namespace {
+
+/// Return the directory that contains the running executable, or an empty path
+/// on failure.  Uses @c /proc/self/exe on Linux and @c _NSGetExecutablePath on
+/// macOS so that the result survives symlinks and spack relocation.
+std::filesystem::path ExeDir() {
+#if defined(__linux__)
+  std::error_code ec;
+  auto p = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (!ec)
+    return p.parent_path();
+#elif defined(__APPLE__)
+  char buf[PATH_MAX];
+  uint32_t size = sizeof(buf);
+  if (_NSGetExecutablePath(buf, &size) == 0)
+    return std::filesystem::canonical(buf).parent_path();
+#endif
+  return {};
+}
+
+/// Build the colon-separated macro search path using a three-tier fallback:
+///  1. @c G4OCCT_MACRO_PATH environment variable (user/admin override).
+///  2. Runtime-detected path relative to the executable
+///     (@c <prefix>/share/g4occt/macros) — correct after spack relocation.
+///  3. Compile-time build-tree path @c G4OCCT_MACRO_DIR_BUILD — for in-tree
+///     development and CTest runs.
+///
+/// All existing, non-empty entries are appended in order so that Geant4's
+/// macro search tries them in priority sequence.
+G4String BuildMacroSearchPath() {
+  std::vector<std::string> dirs;
+
+  // 1. Environment variable override.
+  if (const char* env = std::getenv("G4OCCT_MACRO_PATH"))
+    if (*env != '\0')
+      dirs.emplace_back(env);
+
+  // 2. Runtime path: exe/../share/g4occt/macros.
+  auto exeDir = ExeDir();
+  if (!exeDir.empty()) {
+    auto runtimeDir = exeDir.parent_path() / "share" / "g4occt" / "macros";
+    dirs.push_back(runtimeDir.string());
+  }
+
+  // 3. Build-tree compile-time constant (developer / CTest fallback).
+  dirs.emplace_back(G4OCCT_MACRO_DIR_BUILD);
+
+  G4String path;
+  for (const auto& d : dirs) {
+    if (!path.empty())
+      path += ":";
+    path += d;
+  }
+  return path;
+}
 
 void PrintUsage(const char* prog) {
   G4cerr << "Usage: " << prog
@@ -158,10 +218,12 @@ int main(int argc, char** argv) {
   }
 
   // ── Macro search path ─────────────────────────────────────────────────────
-  // Register the installed data directory first, then the build-tree copy.
-  // This satisfies both `make install` users and in-tree development/testing.
+  // Three-tier fallback so the binary works after spack relocation:
+  //  1. G4OCCT_MACRO_PATH env var  — user/admin override
+  //  2. <exe>/../share/g4occt/macros — runtime-relative (survives relocation)
+  //  3. G4OCCT_MACRO_DIR_BUILD     — in-tree build / CTest
   auto* UImanager = G4UImanager::GetUIpointer();
-  UImanager->SetMacroSearchPath(G4String(G4OCCT_MACRO_DIR_INSTALL) + ":" + G4OCCT_MACRO_DIR_BUILD);
+  UImanager->SetMacroSearchPath(BuildMacroSearchPath());
 
   // ── Execute macro or start interactive session ────────────────────────────
   int exitCode = 0;

--- a/src/app/g4occt/main.cc
+++ b/src/app/g4occt/main.cc
@@ -31,7 +31,7 @@
 #include <vector>
 
 #ifdef __APPLE__
-#  include <mach-o/dyld.h>
+#include <mach-o/dyld.h>
 #endif
 
 namespace {

--- a/src/app/g4occt/main.cc
+++ b/src/app/g4occt/main.cc
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <climits>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
@@ -46,10 +47,14 @@ std::filesystem::path ExeDir() {
   if (!ec)
     return p.parent_path();
 #elif defined(__APPLE__)
-  char buf[PATH_MAX];
+  char buf[PATH_MAX]; // PATH_MAX from <climits>
   uint32_t size = sizeof(buf);
-  if (_NSGetExecutablePath(buf, &size) == 0)
-    return std::filesystem::canonical(buf).parent_path();
+  if (_NSGetExecutablePath(buf, &size) == 0) {
+    std::error_code ec;
+    auto p = std::filesystem::canonical(buf, ec);
+    if (!ec)
+      return p.parent_path();
+  }
 #endif
   return {};
 }
@@ -57,12 +62,14 @@ std::filesystem::path ExeDir() {
 /// Build the colon-separated macro search path using a three-tier fallback:
 ///  1. @c G4OCCT_MACRO_PATH environment variable (user/admin override).
 ///  2. Runtime-detected path relative to the executable
-///     (@c <prefix>/share/g4occt/macros) — correct after spack relocation.
+///     (@c <prefix>/${CMAKE_INSTALL_DATADIR}/g4occt/macros) — correct after
+///     spack relocation; the datadir component is baked in at compile time via
+///     @c G4OCCT_INSTALL_DATADIR.
 ///  3. Compile-time build-tree path @c G4OCCT_MACRO_DIR_BUILD — for in-tree
 ///     development and CTest runs.
 ///
-/// All existing, non-empty entries are appended in order so that Geant4's
-/// macro search tries them in priority sequence.
+/// Only non-empty entries whose path exists on disk are appended, in priority
+/// order, so that Geant4's macro search tries them in priority sequence.
 G4String BuildMacroSearchPath() {
   std::vector<std::string> dirs;
 
@@ -71,10 +78,10 @@ G4String BuildMacroSearchPath() {
     if (*env != '\0')
       dirs.emplace_back(env);
 
-  // 2. Runtime path: exe/../share/g4occt/macros.
+  // 2. Runtime path: exe/../${CMAKE_INSTALL_DATADIR}/g4occt/macros.
   auto exeDir = ExeDir();
   if (!exeDir.empty()) {
-    auto runtimeDir = exeDir.parent_path() / "share" / "g4occt" / "macros";
+    auto runtimeDir = exeDir.parent_path() / G4OCCT_INSTALL_DATADIR / "g4occt" / "macros";
     dirs.push_back(runtimeDir.string());
   }
 
@@ -83,6 +90,11 @@ G4String BuildMacroSearchPath() {
 
   G4String path;
   for (const auto& d : dirs) {
+    if (d.empty())
+      continue;
+    std::error_code ec;
+    if (!std::filesystem::exists(d, ec) || ec)
+      continue;
     if (!path.empty())
       path += ":";
     path += d;


### PR DESCRIPTION
- [x] Review current state of `src/app/g4occt/main.cc` and `CMakeLists.txt`
- [x] Fix macOS branch: add `<climits>` for `PATH_MAX`; use `error_code` overload for `std::filesystem::canonical()`
- [x] Fix hardcoded `"share"` path: pass `CMAKE_INSTALL_DATADIR` as `G4OCCT_INSTALL_DATADIR` compile definition and use it in `BuildMacroSearchPath()`
- [x] Fix comment vs behavior: add `std::filesystem::exists()` filtering so only existing directories are appended
- [x] Code review (clean) and security scan (0 alerts)