### PR TITLE
Convert to native root units (cm)

### DIFF
--- a/src/dd4hep/G4OCCT_STEPSolid.cc
+++ b/src/dd4hep/G4OCCT_STEPSolid.cc
@@ -73,10 +73,12 @@ static Ref_t create_step_solid(Detector& description, xml_h e, SensitiveDetector
                              " triangles, which exceeds TessellatedSolid's int capacity");
   }
   TessellatedSolid tess(name + "_tess", static_cast<int>(nTriangles));
+  // G4OCCT_ImportSTEPSolid returns vertex coordinates in OCCT native units (mm).
+  // TessellatedSolid::Vertex expects ROOT/TGeo units (cm)
   for (const auto& tri : geom.triangles) {
-    tess.addFacet(TessellatedSolid::Vertex(tri.v[0].x, tri.v[0].y, tri.v[0].z),
-                  TessellatedSolid::Vertex(tri.v[1].x, tri.v[1].y, tri.v[1].z),
-                  TessellatedSolid::Vertex(tri.v[2].x, tri.v[2].y, tri.v[2].z));
+    tess.addFacet(TessellatedSolid::Vertex(tri.v[0].x, tri.v[0].y, tri.v[0].z) * dd4hep::mm,
+                  TessellatedSolid::Vertex(tri.v[1].x, tri.v[1].y, tri.v[1].z) * dd4hep::mm,
+                  TessellatedSolid::Vertex(tri.v[2].x, tri.v[2].y, tri.v[2].z) * dd4hep::mm);
   }
   tess.ptr()->CloseShape(/*check=*/true, /*fixFlipped=*/true, /*verbose=*/false);
 

--- a/src/dd4hep/tests/test_dd4hep_plugins.cc
+++ b/src/dd4hep/tests/test_dd4hep_plugins.cc
@@ -9,6 +9,7 @@
 ///  - The expected number of placed volumes.
 ///  - Material assignment for the placed volumes.
 ///  - No DD4hep or Geant4 exceptions during construction.
+///  - Geometric dimensions in DD4hep/ROOT native units (cm), not OCCT mm.
 ///
 /// Tests are labelled "dd4hep" (via CTest LABELS) so they can be run in
 /// isolation with `ctest -L dd4hep` or excluded from other runs with
@@ -17,6 +18,7 @@
 #include <DD4hep/Detector.h>
 #include <DD4hep/DetElement.h>
 #include <DD4hep/Volumes.h>
+#include <TGeoTessellated.h>
 
 #include <gtest/gtest.h>
 
@@ -100,6 +102,38 @@ TEST_F(STEPSolidTest, MaterialAssignment) {
   dd4hep::Volume vol = pv.volume();
   ASSERT_TRUE(vol.isValid());
   EXPECT_TRUE(vol.material().isValid()) << "Volume material is invalid";
+}
+
+/// Verify that the TessellatedSolid's bounding-box half-extents are in
+/// DD4hep/ROOT native units (cm), not in OCCT native units (mm).
+///
+/// The STEP fixture is the box-20x30x40-v1 shape: a 20 × 30 × 40 mm box
+/// centred at the origin.  In ROOT/TGeo/DD4hep units (cm) the bounding-box
+/// half-extents must be 1.0 × 1.5 × 2.0 cm.  If the mm → cm unit conversion
+/// is absent (the regression this test guards against), the half-extents
+/// appear as 10.0 × 15.0 × 20.0 — a factor of ten too large.
+TEST_F(STEPSolidTest, TessellatedSolidBoundsInCm) {
+  ASSERT_NO_THROW(LoadCompact(G4OCCT_COMPACT_STEP_SOLID));
+  dd4hep::Detector& det = dd4hep::Detector::getInstance();
+
+  const auto& children = det.world().children();
+  auto it              = children.find("TestBox");
+  ASSERT_NE(it, children.end()) << "DetElement 'TestBox' not found";
+
+  dd4hep::Volume vol = it->second.placement().volume();
+  ASSERT_TRUE(vol.isValid());
+
+  auto* tess = dynamic_cast<TGeoTessellated*>(vol.solid().ptr());
+  ASSERT_NE(tess, nullptr) << "Volume solid is not a TGeoTessellated";
+
+  // Expected half-extents in cm.  The fixture box is 20 × 30 × 40 mm, so
+  // half-extents are 10 × 15 × 20 mm = 1.0 × 1.5 × 2.0 cm.
+  // For a box (flat faces) the tessellation vertices sit exactly at the
+  // corners, so floating-point error is negligible; 2 % tolerance is ample.
+  constexpr double kRelTol = 0.02;
+  EXPECT_NEAR(tess->GetDX(), 1.0, 1.0 * kRelTol) << "X half-extent should be 1.0 cm (10 mm)";
+  EXPECT_NEAR(tess->GetDY(), 1.5, 1.5 * kRelTol) << "Y half-extent should be 1.5 cm (15 mm)";
+  EXPECT_NEAR(tess->GetDZ(), 2.0, 2.0 * kRelTol) << "Z half-extent should be 2.0 cm (20 mm)";
 }
 
 // ── STEPAssembly tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
The units imported from step CAD models are in mm while dd4hep/root geometry expects cm. This adds the conversion which was missing.

1cm boxes created natively using dd4hep (blue) and imported from CAD (gray):

Before Fix:
<img width="319" height="221" alt="image" src="https://github.com/user-attachments/assets/2a775f54-1f2b-479e-bde4-154fec0c3b2c" />

After fix:
<img width="410" height="164" alt="image" src="https://github.com/user-attachments/assets/d552dbef-867a-4b1f-ac97-c7b095c7c90d" />

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #366)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
